### PR TITLE
Final changes. Added timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,4 @@ jobs:
         password: ${{ secrets.HOST_FTP_PASSWORD }}
         log-level: verbose
         server-dir: /public_html/
+        timeout: 1000


### PR DESCRIPTION
Final changes before fix. The source of the problem was manual deletion of "ftp-deploy-sync-state.json" file in the host storage