### PR TITLE
Added links to lessons again

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
                                 <tr class="table-primary">
                                     <td>Методи медікобіологічних досліджень, практика</td>
                                     <td id="link">
-                                        <a href="">
+                                        <a href="https://zoom.us/j/8739008360?pwd=Y3pEU1NOeU9RdDVXRE1zZ0dRZnc1dz09">
                                             <i class="bi bi-link"></i>
                                         </a>
                                     </td>
@@ -111,7 +111,7 @@
                                     <td>09:50-11:25</td>
                                     <td>Мінор?</td>
                                     <td id="link">
-                                        <a href="">
+                                        <a href="https://us04web.zoom.us/j/77551367339?pwd=dHIJjHhdhq8HAkurNL16BpKIkVFcmb.1">
                                             <i class="bi bi-link"></i>
                                         </a>
                                     </td>
@@ -174,7 +174,7 @@
                                     <td>09:50-11:25</td>
                                     <td>Методи медікобіологічних досліджень, лекція</td>
                                     <td id="link">
-                                        <a href="">
+                                        <a href="https://zoom.us/j/8739008360?pwd=Y3pEU1NOeU9RdDVXRE1zZ0dRZnc1dz09">
                                             <i class="bi bi-link"></i>
                                         </a>
                                     </td>
@@ -185,7 +185,7 @@
                                     <td>11:55-13:30</td>
                                     <td>Методи аналізу медичних даних, лекція</td>
                                     <td id="link">
-                                        <a href="">
+                                        <a href="https://us05web.zoom.us/j/4704452683?pwd=SDBmMEpSWTBjOUJjK2l2UzJxYWdWQT09%20%20Meeting%20ID:%20470%20445%202683%20Passcode:%209xa00i">
                                             <i class="bi bi-link"></i>
                                         </a>
                                     </td>
@@ -196,7 +196,7 @@
                                     <td rowspan="2">13:45-15:20</td>
                                     <td>Методи аналізу медичних даних, практика</td>
                                     <td id="link">
-                                        <a href="">
+                                        <a href="https://us05web.zoom.us/j/4704452683?pwd=SDBmMEpSWTBjOUJjK2l2UzJxYWdWQT09%20%20Meeting%20ID:%20470%20445%202683%20Passcode:%209xa00i">
                                             <i class="bi bi-link"></i>
                                         </a>
                                     </td>
@@ -205,7 +205,7 @@
                                 <tr class="table-primary">
                                     <td>Крос-платформне програмування, практика</td>
                                     <td id="link">
-                                        <a href="">
+                                        <a href="https://us05web.zoom.us/j/9668466411?pwd=aFlWMUhsZDZwMlVWNWU3TktxaGFZZz09">
                                             <i class="bi bi-link"></i>
                                         </a>
                                     </td>
@@ -315,7 +315,7 @@
                                     <td>13:45-15:20</td>
                                     <td>Мінор?</td>
                                     <td id="link">
-                                        <a href="">
+                                        <a href="https://us04web.zoom.us/j/77551367339?pwd=dHIJjHhdhq8HAkurNL16BpKIkVFcmb.1">
                                             <i class="bi bi-link"></i>
                                         </a>
                                     </td>


### PR DESCRIPTION
Why again?
I needed to quickly make the changes to host storage, so I added the links to the lessons manually and Git didn't track this changes. After CD pipeline started working, the HTML file on host was overwritten with an old one without links.