### PR TITLE
Fix/responsive tables only for phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
             <div class="row">
                 <div class="col-12 col-lg-6">
                     <em>Понеділок</em>
-                    <div class="table-responsive">
+                    <div class="table-responsive-xs">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>
@@ -83,7 +83,7 @@
 
                 <div class="col-12 col-lg-6">
                     <em>Вівторок</em>
-                    <div class="table-responsive">
+                    <div class="table-responsive-xs">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>
@@ -150,7 +150,7 @@
             <div class="row">
                 <div class="col-12 col-lg-6">
                     <em>Середа</em>
-                    <div class="table-responsive">
+                    <div class="table-responsive-xs">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>
@@ -218,7 +218,7 @@
 
                 <div class="col-12 col-lg-6">
                     <em>Четвер</em>
-                    <div class="table-responsive">
+                    <div class="table-responsive-xs">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>
@@ -277,7 +277,7 @@
             <div class="row">
                 <div class="col-12">
                     <em>П'ятниця</em>
-                    <div class="table-responsive">
+                    <div class="table-responsive-xs">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>

--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
 
         <div class="container">
             <div class="row">
-                <div class="col-12 col-lg-6">
+                <div class="col-12 col-lg-12 col-xl-6">
                     <em>Понеділок</em>
-                    <div class="table-responsive-xs">
+                    <div class="table-responsive">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>
@@ -81,9 +81,9 @@
                     </div>
                 </div>
 
-                <div class="col-12 col-lg-6">
+                <div class="col-12 col-lg-12 col-xl-6">
                     <em>Вівторок</em>
-                    <div class="table-responsive-xs">
+                    <div class="table-responsive">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>
@@ -150,7 +150,7 @@
             <div class="row">
                 <div class="col-12 col-lg-6">
                     <em>Середа</em>
-                    <div class="table-responsive-xs">
+                    <div class="table-responsive">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>
@@ -218,7 +218,7 @@
 
                 <div class="col-12 col-lg-6">
                     <em>Четвер</em>
-                    <div class="table-responsive-xs">
+                    <div class="table-responsive">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>
@@ -277,7 +277,7 @@
             <div class="row">
                 <div class="col-12">
                     <em>П'ятниця</em>
-                    <div class="table-responsive-xs">
+                    <div class="table-responsive">
                         <table class="table table-bordered">
                             <thead class="table-dark">
                                 <tr>


### PR DESCRIPTION
Earlier, responsive tables have horizontal scrolling on small laptop display (992px - 1200px) and two columns. Expected result: if tables are not fully fit on small laptop's display, then all columns should use 100% (col-12) of width.

To achieve that, columns breakpoints was changed to consider small laptop displays.